### PR TITLE
Add support for DASPI Passage garage door opener

### DIFF
--- a/lib/GarageDoorAccessory.js
+++ b/lib/GarageDoorAccessory.js
@@ -238,15 +238,17 @@ class GarageDoorAccessory extends BaseAccessory {
             }
         } else if (this._isDaspi()) {
             // translate the Daspi strings to the enumerated status values
-            switch (dp) {
+            switch (dp.toLowerCase()) {
                 case GARAGE_DOOR_OPEN:
                 case GARAGE_DOOR_OPENING:
                 case GARAGE_DOOR_OPEN_SOFTSTOP:
+		case GARAGE_DOOR_FULL_OPENED:
                     return this.targetOpen;
 
                 case GARAGE_DOOR_CLOSE:
                 case GARAGE_DOOR_CLOSING:
                 case GARAGE_DOOR_CLOSE_SOFTSTOP:
+		case GARAGE_DOOR_FULL_CLOSED:
                     return this.targetClosed;
 
                 default:
@@ -276,11 +278,11 @@ class GarageDoorAccessory extends BaseAccessory {
             // translate the the enumerated status values to Kogan and Daspi strings
             switch (value) {
                 case this.targetOpen:
-                    newValue = GARAGE_DOOR_OPEN;
+                    newValue = this._isDaspi() ? 'Open' : GARAGE_DOOR_OPEN;
                     break;
 
                 case this.targetClosed:
-                    newValue = GARAGE_DOOR_CLOSE;
+                    newValue = this._isDaspi() ? 'Close' : GARAGE_DOOR_CLOSE;
                     break;
 
                 default:
@@ -342,7 +344,7 @@ class GarageDoorAccessory extends BaseAccessory {
             }
         } else if (this._isDaspi()) {
             // translate the Daspi strings to the enumerated status values
-            switch (dpStatusValue) {
+            switch (dpStatusValue.toLowerCase()) {
                 case GARAGE_DOOR_FULL_OPENED:
                     return this.currentOpen;
 

--- a/lib/GarageDoorAccessory.js
+++ b/lib/GarageDoorAccessory.js
@@ -18,11 +18,21 @@ const GARAGE_DOOR_OPENING =
 const GARAGE_DOOR_CLOSING = 'closing';
 // Kogan garage door appears to have no stopped status
 
+// For Daspi garage door
+const GARAGE_DOOR_FULL_OPENED = 'full_opened';
+const GARAGE_DOOR_FULL_CLOSED = 'full_closed';
+const GARAGE_DOOR_OPEN_SOFTSTOP = 'open_softstop';
+const GARAGE_DOOR_CLOSE_SOFTSTOP = 'close_softstop';
+// Daspi garage door appears to have no stopped status
+
 // Kogan manufacturer name
 const GARAGE_DOOR_MANUFACTURER_KOGAN = 'Kogan';
 
 // Wofea manufacturer name
 const GARAGE_DOOR_MANUFACTURER_WOFEA = 'Wofea';
+
+// Daspi manufacturer name
+const GARAGE_DOOR_MANUFACTURER_DASPI = 'Daspi';
 
 // main code
 class GarageDoorAccessory extends BaseAccessory {
@@ -77,6 +87,15 @@ class GarageDoorAccessory extends BaseAccessory {
       }
   }
 
+    // function to return true if the garage door manufacturer is Daspi
+    _isDaspi() {
+        if (this.manufacturer === GARAGE_DOOR_MANUFACTURER_DASPI.trim()) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     _registerCharacteristics(dps) {
         const {Service, Characteristic} = this.hap;
         const service = this.accessory.getService(Service.GarageDoorOpener);
@@ -99,6 +118,9 @@ class GarageDoorAccessory extends BaseAccessory {
         } else if (this.device.context.manufacturer.trim().toLowerCase() ===
             GARAGE_DOOR_MANUFACTURER_WOFEA.trim().toLowerCase()) {
             this.manufacturer = this.device.context.manufacturer.trim();
+        } else if (this.device.context.manufacturer.trim().toLowerCase() ===
+            GARAGE_DOOR_MANUFACTURER_DASPI.trim().toLowerCase()) {
+            this.manufacturer = this.device.context.manufacturer.trim();
         } else if (this.device.context.manufacturer) {
             this.manufacturer = this.device.context.manufacturer.trim();
         } else {
@@ -119,6 +141,14 @@ class GarageDoorAccessory extends BaseAccessory {
                 GARAGE_DOOR_MANUFACTURER_WOFEA + ' garage door');
             this.dpAction = this._getCustomDP(this.device.context.dpAction) || '1';
             this.dpStatus = this._getCustomDP(this.device.context.dpStatus) || '101';
+        }
+        else if (this._isDaspi()) {
+            // Daspi Passage Garage Door Opener
+            this._debugLog(
+                '_registerCharacteristics setting dpAction and dpStatus for ' +
+                GARAGE_DOOR_MANUFACTURER_DASPI + ' garage door');
+            this.dpAction = this._getCustomDP(this.device.context.dpAction) || '1';
+            this.dpStatus = this._getCustomDP(this.device.context.dpStatus) || '7';
         } else {
             // the original garage door opener
             this._debugLog(
@@ -206,6 +236,23 @@ class GarageDoorAccessory extends BaseAccessory {
                     this._alwaysLog('_getTargetDoorState UNKNOWN STATE ' +
                         JSON.stringify(dp));
             }
+        } else if (this._isDaspi()) {
+            // translate the Daspi strings to the enumerated status values
+            switch (dp) {
+                case GARAGE_DOOR_OPEN:
+                case GARAGE_DOOR_OPENING:
+                case GARAGE_DOOR_OPEN_SOFTSTOP:
+                    return this.targetOpen;
+
+                case GARAGE_DOOR_CLOSE:
+                case GARAGE_DOOR_CLOSING:
+                case GARAGE_DOOR_CLOSE_SOFTSTOP:
+                    return this.targetClosed;
+
+                default:
+                    this._alwaysLog('_getTargetDoorState UNKNOWN STATE ' +
+                        JSON.stringify(dp));
+            }
         } else {
             // Generic garage door uses true for the opened status and false for the
             // closed status
@@ -225,8 +272,8 @@ class GarageDoorAccessory extends BaseAccessory {
         this._debugLog('setTargetDoorState value ' + value + ' targetOpen ' +
             this.targetOpen + ' targetClosed ' + this.targetClosed);
 
-        if (this._isKogan()) {
-            // translate the the enumerated status values to Kogan strings
+        if (this._isKogan() || this._isDaspi()) {
+            // translate the the enumerated status values to Kogan and Daspi strings
             switch (value) {
                 case this.targetOpen:
                     newValue = GARAGE_DOOR_OPEN;
@@ -240,7 +287,7 @@ class GarageDoorAccessory extends BaseAccessory {
                     this._alwaysLog('setTargetDoorState UNKNOWN STATE ' +
                         JSON.stringify(value));
             }
-        } else {
+        } else  {
             // Generic garage door uses true for the open action and false for the
             // close action
             switch (value) {
@@ -287,6 +334,27 @@ class GarageDoorAccessory extends BaseAccessory {
                     return this.currentClosing;
 
                 case GARAGE_DOOR_CLOSED:
+                    return this.currentClosed;
+
+                default:
+                    this._alwaysLog('_getCurrentDoorState UNKNOWN STATUS ' +
+                        JSON.stringify(dpStatusValue));
+            }
+        } else if (this._isDaspi()) {
+            // translate the Daspi strings to the enumerated status values
+            switch (dpStatusValue) {
+                case GARAGE_DOOR_FULL_OPENED:
+                    return this.currentOpen;
+
+                case GARAGE_DOOR_OPEN_SOFTSTOP:
+                case GARAGE_DOOR_OPENING:
+                    return this.currentOpening;
+
+                case GARAGE_DOOR_CLOSE_SOFTSTOP:
+                case GARAGE_DOOR_CLOSING:
+                    return this.currentClosing;
+
+                case GARAGE_DOOR_FULL_CLOSED:
                     return this.currentClosed;
 
                 default:


### PR DESCRIPTION
**Description:**
This pull request adds support for the DASPI Passage garage door opener to the **homebridge-tuya-platform-local** plugin. The changes primarily involve updates to the `GarageDoorAccessory.js` file to accommodate the device's specific attributes and functionality.

**Testing:**
- Verified that the DASPI Passage responds correctly to HomeKit commands.
- Tested status reporting for the garage door (open, closed, partially open).